### PR TITLE
Silence GCC 11 warnings

### DIFF
--- a/ext/digest/sha2/sha2.c
+++ b/ext/digest/sha2/sha2.c
@@ -575,7 +575,7 @@ void SHA256_Update(SHA256_CTX* context, const sha2_byte *data, size_t len) {
 	usedspace = freespace = 0;
 }
 
-int SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
+int SHA256_Final(sha2_byte digest[SHA256_DIGEST_LENGTH], SHA256_CTX* context) {
 	sha2_word32	*d = (sha2_word32*)digest;
 	unsigned int	usedspace;
 
@@ -640,7 +640,7 @@ int SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
 	return 1;
 }
 
-char *SHA256_End(SHA256_CTX* context, char buffer[]) {
+char *SHA256_End(SHA256_CTX* context, char buffer[SHA256_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA256_DIGEST_LENGTH], *d = digest;
 	int		i;
 
@@ -943,7 +943,7 @@ void SHA512_Last(SHA512_CTX* context) {
 	SHA512_Transform(context, (sha2_word64*)context->buffer);
 }
 
-int SHA512_Final(sha2_byte digest[], SHA512_CTX* context) {
+int SHA512_Final(sha2_byte digest[SHA512_DIGEST_LENGTH], SHA512_CTX* context) {
 	sha2_word64	*d = (sha2_word64*)digest;
 
 	/* Sanity check: */
@@ -973,7 +973,7 @@ int SHA512_Final(sha2_byte digest[], SHA512_CTX* context) {
 	return 1;
 }
 
-char *SHA512_End(SHA512_CTX* context, char buffer[]) {
+char *SHA512_End(SHA512_CTX* context, char buffer[SHA512_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA512_DIGEST_LENGTH], *d = digest;
 	int		i;
 
@@ -1019,7 +1019,7 @@ void SHA384_Update(SHA384_CTX* context, const sha2_byte* data, size_t len) {
 	SHA512_Update((SHA512_CTX*)context, data, len);
 }
 
-int SHA384_Final(sha2_byte digest[], SHA384_CTX* context) {
+int SHA384_Final(sha2_byte digest[SHA384_DIGEST_LENGTH], SHA384_CTX* context) {
 	sha2_word64	*d = (sha2_word64*)digest;
 
 	/* Sanity check: */
@@ -1049,7 +1049,7 @@ int SHA384_Final(sha2_byte digest[], SHA384_CTX* context) {
 	return 1;
 }
 
-char *SHA384_End(SHA384_CTX* context, char buffer[]) {
+char *SHA384_End(SHA384_CTX* context, char buffer[SHA384_DIGEST_STRING_LENGTH]) {
 	sha2_byte	digest[SHA384_DIGEST_LENGTH], *d = digest;
 	int		i;
 


### PR DESCRIPTION
```
In file included from ../../../../ext/digest/sha2/sha2.c:40:
../../../../ext/digest/sha2/sha2.c:578:28: warning: argument 2 of type 'sha2_byte[]' {aka 'unsigned char[]'} with mismatched bound [-Warray-parameter=]
  578 | int SHA256_Final(sha2_byte digest[], SHA256_CTX* context) {
      |                  ~~~~~~~~~~^~~~~~~~
../../../../ext/digest/sha2/sha2.h:145:50: note: in definition of macro 'SHA256_Final'
  145 | #define SHA256_Final(d, c)      SHA256_Finish(c, d)
      |                                                  ^
../../../../ext/digest/sha2/sha2.h:170:18: note: previously declared as 'uint8_t[32]' {aka 'unsigned char[32]'}
  170 | int SHA256_Final(uint8_t[SHA256_DIGEST_LENGTH], SHA256_CTX*);
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/digest/sha2/sha2.h:145:50: note: in definition of macro 'SHA256_Final'
  145 | #define SHA256_Final(d, c)      SHA256_Finish(c, d)
      |                                                  ^
```