### PR TITLE
Change const_missing require for SHA2

### DIFF
--- a/lib/digest.rb
+++ b/lib/digest.rb
@@ -8,7 +8,7 @@ module Digest
   def self.const_missing(name) # :nodoc:
     case name
     when :SHA256, :SHA384, :SHA512
-      lib = 'digest/sha2.so'
+      lib = 'digest/sha2.rb'
     else
       lib = File.join('digest', name.to_s.downcase)
     end


### PR DESCRIPTION
Require sha2.rb instead of sha2.so.  With a change proposed for
Ruby feature 15856, once sha2.so is loaded, require 'sha2' will
not load sha2.rb, resulting in Digest::SHA2 not being defined
in the following case:

```ruby
require "digest"
p Digest::SHA256 #=> Digest::SHA256
p Digest::SHA2
```

As digest/sha2.rb requires digest/sha2.so, this should not cause
any backwards compatibility issues.

Patch from Dan0042 (Daniel DeLorme)