### PR TITLE
CI: Use bundler-cache: true

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - run: bundle install
+          bundler-cache: true # 'bundle install' and cache
 
       - run: bundle exec rake compile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,8 @@ jobs:
 
       - run: bundle exec rake test
 
-      - run: rake check
+      - name: Standalone integration test
+        run: |
+          gem install rake rake-compiler
+          rake check
         continue-on-error: ${{ matrix.ignore-pkg-error || (matrix.ruby == 'debug') }}


### PR DESCRIPTION


This PR uses the `bundler-cache` feature of the Ruby-maintained Action `ruby/setup-ruby`. This installs and caches the gems.

[See `ruby/setup-ruby` parameters declaration](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.

 In order to use the Bundler-installed gems, this also add `bundle exec` to the rake tasks.

(`rake-compiler` seems not to be found when reading the Rakefile, for some reason. **Update**: right, that's because I was not using `bundle exec`.)