### PR TITLE
Expose Digest::VERSION

### DIFF
--- a/digest.gemspec
+++ b/digest.gemspec
@@ -1,9 +1,11 @@
 # coding: utf-8
 # frozen_string_literal: true
 
+require_relative 'lib/digest/version'
+
 Gem::Specification.new do |spec|
   spec.name          = "digest"
-  spec.version       = "3.1.0.pre2"
+  spec.version       = Digest::VERSION
   spec.authors       = ["Akinori MUSHA"]
   spec.email         = ["knu@idaemons.org"]
 

--- a/lib/digest.rb
+++ b/lib/digest.rb
@@ -14,6 +14,7 @@
 #   %r{/(rubygems/gem_runner|bundler/cli)\.rb}.match?(l.path)
 # }
 
+require 'digest/version'
 require 'digest/loader'
 
 module Digest

--- a/lib/digest/version.rb
+++ b/lib/digest/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Digest
+  VERSION = "3.1.0.pre2"
+end


### PR DESCRIPTION
It's kind of a standard patterns for gems, and would be useful to figure which version is loaded as it's particularly not obvious since `Digest` is a default gem.

cc @knu 