### PR TITLE
Avoid redefined constant REQUIRE_MUTEX warning on Ruby 2.7 & 3.1

### DIFF
--- a/lib/digest.rb
+++ b/lib/digest.rb
@@ -17,7 +17,7 @@ require 'digest/loader'
 
 module Digest
   # A mutex for Digest().
-  REQUIRE_MUTEX = Thread::Mutex.new
+  REQUIRE_MUTEX ||= Thread::Mutex.new
 
   def self.const_missing(name) # :nodoc:
     case name


### PR DESCRIPTION
Following efd76821b8a467c193c753104c29b476debbb2c9 I am getting `warning: already initialized constant Digest::REQUIRE_MUTEX` using Rails + Spring + rbenv + Ruby 2.7.4.

## Steps to reproduce

```sh
rbenv shell 2.7.4
gem install rails -v 7.0.2.3
rails new test-digest
cd test-digest
bundle add spring
bundle exec spring binstub --all
bin/rails runner 'puts "ok"'
```
Outputs:

<img width="1065" alt="Screenshot of console with warning: already initialized constant Digest::REQUIRE_MUTEX" src="https://user-images.githubusercontent.com/132/159444838-dc95f98e-87aa-4d40-8d36-1b0c5a315f47.png">

Repository with the above steps to reproduce: https://github.com/sunny/test-digest

```sh
git clone git@github.com:sunny/test-digest.git && cd test-digest
bundle install
bin/rails runner 'puts "ok"'
```

## After this change

The warning disappears.

<img width="1064" alt="Screenshot of console without warnings" src="https://user-images.githubusercontent.com/132/159445011-1b6e950b-dfd1-4ebf-8e0f-710c75aea67f.png">
