### PR TITLE
Use CommonDigest by default if available

### DIFF
--- a/ext/digest/digest_conf.rb
+++ b/ext/digest/digest_conf.rb
@@ -3,7 +3,7 @@
 def digest_conf(name)
   unless with_config("bundled-#{name}")
     cc = with_config("common-digest")
-    if cc == true or /\b#{name}\b/ =~ cc
+    if cc != false or /\b#{name}\b/ =~ cc
       if File.exist?("#$srcdir/#{name}cc.h") and
         have_header("CommonCrypto/CommonDigest.h")
         $defs << "-D#{name.upcase}_USE_COMMONDIGEST"


### PR DESCRIPTION
digest/sha2 seems about 2x faster.
