### PR TITLE
Ubuntu 18.04 in GHA is deprecated from Aug 8,2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
+        - ubuntu-22.04
         - ubuntu-20.04
-        - ubuntu-18.04
         - macos-12
         - macos-11
         - windows-latest


### PR DESCRIPTION
And I added Ubuntu 22.04