### PR TITLE
Ignore copied loader.rb files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/lib/digest/loader.rb
+/lib/digest/sha2/loader.rb
 lib/*.jar
 *.bundle
 *.so


### PR DESCRIPTION
`rake compile` copies them from ext/digest or ext/java.