### PR TITLE
Eliminate usages of the old non-typed API

### DIFF
--- a/ext/digest/digest.h
+++ b/ext/digest/digest.h
@@ -64,10 +64,4 @@ rb_id_metadata(void)
     return rb_intern_const("metadata");
 }
 
-static inline VALUE
-rb_digest_make_metadata(const rb_digest_metadata_t *meta)
-{
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
-    return rb_obj_freeze(Data_Wrap_Struct(0, 0, 0, (void *)meta));
-}
+VALUE rb_digest_make_metadata(const rb_digest_metadata_t *meta);


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/19998

I'd like to enable deprecation warnings for the old API so that gem authors can be made aware that it would be best to upgrade to `TypedData`.

Digest is one of the last users of it inside Ruby itself.