### PR TITLE
Use typed data in digest

### DIFF
--- a/ext/digest/digest.c
+++ b/ext/digest/digest.c
@@ -534,7 +534,7 @@ rb_digest_class_init(VALUE self)
  *
  *
  *  rb_ivar_set(cDigest_SHA1, rb_intern("metadata"),
- *		Data_Wrap_Struct(0, 0, 0, (void *)&sha1));
+ *		rb_digest_make_metadata(&sha1));
  */
 
 #ifdef DIGEST_USE_RB_EXT_RESOLVE_SYMBOL


### PR DESCRIPTION
Recently Ruby 3.4 warns use of "untyped data" classes.
This PR makes digest to use `rb_ext_resolve_symbol` that is provided since Ruby 3.3, in 3.4 or later.
Note that the function is not used with 3.3, for the binary compatibility's sake, since the digest bundled with 3.3 does not use it.