### PR TITLE
.github/workflows/ci.yml - add workflow-dispatch, update Rubies, misc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,39 +3,43 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '15 9 * * *'
 
 jobs:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      engine: cruby-truffleruby
+      min_version: 2.7
   host:
+    needs: ruby-versions
     name: ${{ matrix.os }} ${{ matrix.ruby }}
     if: ${{ github.repository == 'ruby/digest' || github.event_name != 'schedule' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - ubuntu-22.04
-        - ubuntu-20.04
-        - macos-12
-        - macos-11
-        - windows-latest
-        ruby:
-        - '3.1'
-        - '3.0'
-        - 2.7
-        - debug
-        include:
-        - { os: ubuntu-20.04,   ruby: head, ignore-pkg-error: true }
-        - { os: windows-latest, ruby: mingw, ignore-pkg-error: true }
-        - { os: windows-latest, ruby: mswin, ignore-pkg-error: true }
-        - { os: ubuntu-20.04,   ruby: jruby }
-        - { os: ubuntu-20.04,   ruby: jruby-head, ignore-pkg-error: true, ignore-error: true }
+        # ubuntu-22.04 uses OpenSSL 3.0, ubuntu-20.04 uses OpenSSL 1.1.1
+        os: [ ubuntu-22.04, ubuntu-20.04, macos-latest, windows-latest ]
+        ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         exclude:
-        - { os: windows-latest, ruby: debug }
+          - { os: windows-latest, ruby: truffleruby }
+          - { os: windows-latest, ruby: truffleruby-head }
+          - { os: macos-latest,   ruby: truffleruby }
+          - { os: ubuntu-20.04,   ruby: truffleruby }
+          - { os: windows-latest, ruby: debug }
+        include:
+          - { os: windows-latest, ruby: ucrt }
+          - { os: windows-latest, ruby: mswin }
+          - { os: ubuntu-latest,  ruby: jruby-9.3 } # Ruby 2.7
+          - { os: ubuntu-latest,  ruby: jruby-9.4 } # Ruby 3.1
+          - { os: ubuntu-20.04,   ruby: jruby-head, ignore-pkg-error: true, ignore-error: true }
+
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
CI is not running here.  It needs to be re-enabled, as there was no activity for 60+ days.

This PR updates the following:

1. Use actions/checkout@v4
2. Updated the matrix ruby version to use `ruby/actions/.github/workflows/ruby_versions.yml`, similar to ruby/openssl.  The current was running a very limited set of Rubies.

See https://github.com/MSP-Greg/digest/actions/runs/9428329026 for the run in my fork.  Several issues, Windows head builds and TruffleRuby.