### PR TITLE
Allow integration test on Windows (RubyGems fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,4 @@ jobs:
           ${{
           matrix.ignore-pkg-error ||
           (matrix.ruby == 'debug') ||
-          startsWith(matrix.os, 'windows') ||
           false }}


### PR DESCRIPTION
This was caused by RubyGems incorrectly activating the wrong gem.  https://github.com/rubygems/rubygems/pull/7743 fixed the problem, and has been pushed to ruby/ruby, and is present in the ruby-loco builds used in CI.