### PR TITLE
Suppress md5 deprecation warnings by gcc as well as clang

### DIFF
--- a/ext/digest/md5/md5cc.h
+++ b/ext/digest/md5/md5cc.h
@@ -1,8 +1,16 @@
 #define COMMON_DIGEST_FOR_OPENSSL 1
 #include <CommonCrypto/CommonDigest.h>
 
-#ifdef __clang__
-# pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#ifdef __GNUC__
+# define RB_DIGEST_DIAGNOSTIC(compiler, op, flag) _Pragma(STRINGIZE(compiler diagnostic op flag))
+# ifdef RBIMPL_WARNING_IGNORED
+#   define RB_DIGEST_WARNING_IGNORED(flag) RBIMPL_WARNING_IGNORED(flag)
+# elif defined(__clang__)
+#   define RB_DIGEST_WARNING_IGNORED(flag) RB_DIGEST_DIAGNOSTIC(clang, ignored, #flag)
+# else /* __GNUC__ */
+#   define RB_DIGEST_WARNING_IGNORED(flag) RB_DIGEST_DIAGNOSTIC(GCC, ignored, #flag)
+# endif
+RB_DIGEST_WARNING_IGNORED(-Wdeprecated-declarations)
 /* Suppress deprecation warnings of MD5 from Xcode 11.1 */
 /* Although we know MD5 is deprecated too, provide just for backward
  * compatibility, as well as Apple does. */


### PR DESCRIPTION
When using gcc 13 on macOS:

```
In file included from ../../../../src/ext/digest/md5/md5init.c:7:
../../../../src/ext/digest/md5/md5cc.h: In function 'rb_digest_MD5_update':
../../../../src/ext/digest/md5/md5cc.h:13:1: warning: 'CC_MD5_Update' is deprecated: This function is cryptographically broken and should not be used in security contexts. Clients should migrate to SHA256 (or stronger). [-Wdeprecated-declarations]
   13 | static DEFINE_UPDATE_FUNC_FOR_UINT(MD5)
      | ^~~~~~
In file included from ../../../../src/ext/digest/md5/md5cc.h:2:
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/CommonCrypto/CommonDigest.h:136:12: note: declared here
  136 | extern int CC_MD5_Update(CC_MD5_CTX *c, const void *data, CC_LONG len)
      |            ^~~~~~~~~~~~~
../../../../src/ext/digest/md5/md5cc.h:13:1: warning: 'CC_MD5_Update' is deprecated: This function is cryptographically broken and should not be used in security contexts. Clients should migrate to SHA256 (or stronger). [-Wdeprecated-declarations]
   13 | static DEFINE_UPDATE_FUNC_FOR_UINT(MD5)
      | ^~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/CommonCrypto/CommonDigest.h:136:12: note: declared here
  136 | extern int CC_MD5_Update(CC_MD5_CTX *c, const void *data, CC_LONG len)
      |            ^~~~~~~~~~~~~
../../../../src/ext/digest/md5/md5cc.h: In function 'rb_digest_MD5_finish':
../../../../src/ext/digest/md5/md5cc.h:14:1: warning: 'CC_MD5_Final' is deprecated: This function is cryptographically broken and should not be used in security contexts. Clients should migrate to SHA256 (or stronger). [-Wdeprecated-declarations]
   14 | static DEFINE_FINISH_FUNC_FROM_FINAL(MD5)
      | ^~~~~~
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/CommonCrypto/CommonDigest.h:139:12: note: declared here
  139 | extern int CC_MD5_Final(unsigned char *md, CC_MD5_CTX *c)
      |            ^~~~~~~~~~~~
../../../../src/ext/digest/md5/md5init.c: At top level:
../../../../src/ext/digest/md5/md5init.c:17:5: warning: 'CC_MD5_Init' is deprecated: This function is cryptographically broken and should not be used in security contexts. Clients should migrate to SHA256 (or stronger). [-Wdeprecated-declarations]
   17 |     (rb_digest_hash_init_func_t)MD5_Init,
      |     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/CommonCrypto/CommonDigest.h:133:12: note: declared here
  133 | extern int CC_MD5_Init(CC_MD5_CTX *c)
      |            ^~~~~~~~~~~
```