### PR TITLE
Deprecate macos-12 test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
         os:
         - ubuntu-22.04
         - ubuntu-20.04
+        - macos-14
         - macos-13
-        - macos-12
         - windows-latest
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         include:


### PR DESCRIPTION
macos-12 is deprecated now. We should update it to macos-14