### PR TITLE
Fix `--without-common-digest` option

### DIFF
--- a/ext/digest/digest_conf.rb
+++ b/ext/digest/digest_conf.rb
@@ -2,14 +2,16 @@
 
 def digest_conf(name)
   unless with_config("bundled-#{name}")
-    cc = with_config("common-digest")
-    if cc != false or /\b#{name}\b/ =~ cc
-      if File.exist?("#$srcdir/#{name}cc.h") and
-        have_header("CommonCrypto/CommonDigest.h")
-        $defs << "-D#{name.upcase}_USE_COMMONDIGEST"
-        $headers << "#{name}cc.h"
-        return :commondigest
-      end
+    case cc = with_config("common-digest", true)
+    when true, false
+    else
+      cc = cc.split(/[\s,]++/).any? {|pat| File.fnmatch?(pat, name)}
+    end
+    if cc and File.exist?("#$srcdir/#{name}cc.h") and
+      have_header("CommonCrypto/CommonDigest.h")
+      $defs << "-D#{name.upcase}_USE_COMMONDIGEST"
+      $headers << "#{name}cc.h"
+      return :commondigest
     end
   end
   $objs << "#{name}.#{$OBJEXT}"


### PR DESCRIPTION
In `digest_conf`, "no implicit conversion of false into String" TypeError is raised.