### PR TITLE
Warnings

### DIFF
--- a/ext/digest/defs.h
+++ b/ext/digest/defs.h
@@ -16,4 +16,26 @@
 # define __END_DECLS
 #endif
 
+#define RB_DIGEST_DIAGNOSTIC(compiler, op, flag) _Pragma(STRINGIZE(compiler diagnostic op flag))
+#ifdef RBIMPL_WARNING_IGNORED
+# define RB_DIGEST_WARNING_IGNORED(flag) RBIMPL_WARNING_IGNORED(flag)
+# define RB_DIGEST_WARNING_PUSH() RBIMPL_WARNING_PUSH()
+# define RB_DIGEST_WARNING_POP() RBIMPL_WARNING_POP()
+#elif defined(__clang__)
+# define RB_DIGEST_WARNING_IGNORED(flag) RB_DIGEST_DIAGNOSTIC(clang, ignored, #flag)
+# define RB_DIGEST_WARNING_PUSH() _Pragma("clang diagnostic push")
+# define RB_DIGEST_WARNING_POP() _Pragma("clang diagnostic pop")
+#else /* __GNUC__ */
+# define RB_DIGEST_WARNING_IGNORED(flag) RB_DIGEST_DIAGNOSTIC(GCC, ignored, #flag)
+# define RB_DIGEST_WARNING_PUSH() _Pragma("GCC diagnostic push")
+# define RB_DIGEST_WARNING_POP() _Pragma("GCC diagnostic pop")
+#endif
+#ifdef RBIMPL_HAS_WARNING
+# define RB_DIGEST_HAS_WARNING(_) RBIMPL_HAS_WARNING(_)
+#elif defined(__has_warning)
+# define RB_DIGEST_HAS_WARNING(_) __has_warning(_)
+#else
+# define RB_DIGEST_HAS_WARNING(_) 0
+#endif
+
 #endif /* DEFS_H */

--- a/ext/digest/md5/md5cc.h
+++ b/ext/digest/md5/md5cc.h
@@ -2,14 +2,6 @@
 #include <CommonCrypto/CommonDigest.h>
 
 #ifdef __GNUC__
-# define RB_DIGEST_DIAGNOSTIC(compiler, op, flag) _Pragma(STRINGIZE(compiler diagnostic op flag))
-# ifdef RBIMPL_WARNING_IGNORED
-#   define RB_DIGEST_WARNING_IGNORED(flag) RBIMPL_WARNING_IGNORED(flag)
-# elif defined(__clang__)
-#   define RB_DIGEST_WARNING_IGNORED(flag) RB_DIGEST_DIAGNOSTIC(clang, ignored, #flag)
-# else /* __GNUC__ */
-#   define RB_DIGEST_WARNING_IGNORED(flag) RB_DIGEST_DIAGNOSTIC(GCC, ignored, #flag)
-# endif
 RB_DIGEST_WARNING_IGNORED(-Wdeprecated-declarations)
 /* Suppress deprecation warnings of MD5 from Xcode 11.1 */
 /* Although we know MD5 is deprecated too, provide just for backward

--- a/ext/digest/md5/md5init.c
+++ b/ext/digest/md5/md5init.c
@@ -3,6 +3,7 @@
 
 #include <ruby/ruby.h>
 #include "../digest.h"
+#include "../defs.h"
 #if defined(MD5_USE_COMMONDIGEST)
 #include "md5cc.h"
 #else

--- a/ext/digest/sha1/sha1.c
+++ b/ext/digest/sha1/sha1.c
@@ -232,8 +232,14 @@ void SHA1_Update(SHA1_CTX *context, const uint8_t *data, size_t len)
     if ((j + len) > 63) {
 	(void)memcpy(&context->buffer[j], data, (i = 64-j));
 	SHA1_Transform(context->state, context->buffer);
-	for ( ; i + 63 < len; i += 64)
+	for ( ; i + 63 < len; i += 64) {
+	    RB_DIGEST_WARNING_PUSH();
+#if defined(__GNUC__) && !defined(__clang__)
+	    RB_DIGEST_WARNING_IGNORED(-Wstringop-overread);
+#endif
 	    SHA1_Transform(context->state, &data[i]);
+	    RB_DIGEST_WARNING_POP();
+	}
 	j = 0;
     } else {
 	i = 0;


### PR DESCRIPTION
Suppress false warning in sha1.c by gcc.

Because `data` should have `len` bytes and the loop condition `i + 63 < len`, `data` has 64 bytes at least after index `i`.

```
In function 'rb_Digest_SHA1_Update',
    inlined from 'rb_Digest_SHA1_Finish' at ../../../../src/ext/digest/sha1/sha1.c:262:2:
../../../../src/ext/digest/sha1/sha1.h:24:25: warning: 'rb_Digest_SHA1_Transform' reading 64 bytes from a region of size 1 [-Wstringop-overread]
   24 | #define SHA1_Transform  rb_Digest_SHA1_Transform
../../../../src/ext/digest/sha1/sha1.c:236:13: note: in expansion of macro 'SHA1_Transform'
  236 |             SHA1_Transform(context->state, &data[i]);
      |             ^~~~~~~~~~~~~~
../../../../src/ext/digest/sha1/sha1.h:24:25: note: referencing argument 2 of type 'const uint8_t[64]' {aka 'const unsigned char[64]'}
   24 | #define SHA1_Transform  rb_Digest_SHA1_Transform
../../../../src/ext/digest/sha1/sha1.c:236:13: note: in expansion of macro 'SHA1_Transform'
  236 |             SHA1_Transform(context->state, &data[i]);
      |             ^~~~~~~~~~~~~~
../../../../src/ext/digest/sha1/sha1.c: In function 'rb_Digest_SHA1_Finish':
../../../../src/ext/digest/sha1/sha1.h:24:25: note: in a call to function 'rb_Digest_SHA1_Transform'
   24 | #define SHA1_Transform  rb_Digest_SHA1_Transform
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~
../../../../src/ext/digest/sha1/sha1.c:132:6: note: in expansion of macro 'SHA1_Transform'
  132 | void SHA1_Transform(uint32_t state[5], const uint8_t buffer[64])
      |      ^~~~~~~~~~~~~~
```