### PR TITLE
Fix Digest::SHA1#update with large input

### DIFF
--- a/ext/digest/sha1/sha1.c
+++ b/ext/digest/sha1/sha1.c
@@ -220,14 +220,16 @@ int SHA1_Init(SHA1_CTX *context)
  */
 void SHA1_Update(SHA1_CTX *context, const uint8_t *data, size_t len)
 {
-    uint32_t i, j;
+    size_t i;
+    uint32_t j;
 
     _DIAGASSERT(context != 0);
     _DIAGASSERT(data != 0);
 
     j = context->count[0];
     if ((context->count[0] += len << 3) < j)
-	context->count[1] += (len>>29)+1;
+	context->count[1]++;
+    context->count[1] += (uint32_t)(len >> 29);
     j = (j >> 3) & 63;
     if ((j + len) > 63) {
 	(void)memcpy(&context->buffer[j], data, (i = 64-j));


### PR DESCRIPTION
`Digest::SHA1#update` fails when a very large String is passed in a single call.

Passing 2**29 bytes (512 MB) or more at once does not update the message length counter correctly, which results in producing an incorrect output.

    $ ruby -rdigest -e'd=Digest::SHA1.new; d<<"a"*(512*1024*1024); puts d.hexdigest'
    40cd9c4b14e7b8d0940a3a92c8a7661fad85a821
    $ ruby -rdigest -e'd=Digest::SHA1.new; 512.times{d<<"a"*(1024*1024)}; puts d.hexdigest'
    0ea59bfe8787939816796610c73deb1c625e03ed
    $ ruby -e'print "a"*(512*1024*1024)'|sha1sum
    0ea59bfe8787939816796610c73deb1c625e03ed  -

Passing 2**32 bytes or more causes an infinite loop because the loop counter is too small.