### PR TITLE
Fix -Wmaybe-uninitialized

### DIFF
--- a/ext/digest/digest.c
+++ b/ext/digest/digest.c
@@ -571,7 +571,7 @@ static rb_digest_metadata_t *
 get_digest_base_metadata(VALUE klass)
 {
     VALUE p;
-    VALUE obj;
+    VALUE obj = Qnil;
     rb_digest_metadata_t *algo;
 
     for (p = klass; !NIL_P(p); p = rb_class_superclass(p)) {


### PR DESCRIPTION
This PR suppresses this compiler warning:

```
../../../ext/digest/digest.c: In function ‘get_digest_base_metadata’:
  ../../../ext/digest/digest.c:587:12: warning: ‘obj’ may be used uninitialized [-Wmaybe-uninitialized]
    587 |     algo = get_metadata_ptr(obj);
        |            ^~~~~~~~~~~~~~~~~~~~~
  ../../../ext/digest/digest.c:574:11: note: ‘obj’ was declared here
    574 |     VALUE obj;
        |           ^~~
```