### PR TITLE
Skip TestCRC32 on platforms without the C extension (e.g. JRuby)

### DIFF
--- a/test/digest/test_digest.rb
+++ b/test/digest/test_digest.rb
@@ -204,7 +204,7 @@ module TestDigest
       Data1 => "352441c2",
       Data2 => "171a3f5f",
     }
-  end
+  end if defined?(Digest::CRC32)
 
   class TestBase < Test::Unit::TestCase
     def test_base


### PR DESCRIPTION
This PR attempts to skip JRuby testing for Digest::CRC32 if that's not there yet. Like on JRuby, where the C extension cannot be loaded, and there's no CRC32 impl.

(#86 introduced CRC32.)