### PR TITLE
Don't use _Atomic in C99 mode

### DIFF
--- a/ext/digest/blake3/extconf.rb
+++ b/ext/digest/blake3/extconf.rb
@@ -78,6 +78,15 @@ $objs = objs.map { |o| "#{o}.#{$OBJEXT}" }
 
 have_header("sys/cdefs.h")
 
+checking_for("C11 atomics") do
+  unless try_compile(<<~C)
+      static _Atomic int atomic_int = 0;
+      int main(void){ return 0 }
+    C
+    $defs << "-DBLAKE3_ATOMICS=0"
+  end
+end
+
 $preload = %w[digest]
 
 create_makefile("digest/blake3")


### PR DESCRIPTION
```
/github/workspace/src/ext/digest/blake3/blake3_dispatch.c:108:5: error: '_Atomic' is a C11 extension [-Werror,-Wc11-extensions]
      108 |     ATOMIC_INT g_cpu_features = UNDEFINED;
          |     ^
/github/workspace/src/ext/digest/blake3/blake3_dispatch.c:34:20: note: expanded from macro 'ATOMIC_INT'
       34 | #define ATOMIC_INT _Atomic int
          |                    ^
1 error generated.
```

This atomic is used to cache the CPU features, it doesn't need very strong atomic semantic, just avoid reaping, which isn't a big concern.