### PR TITLE
Revert #140 in favor of #141

### DIFF
--- a/ext/digest/blake3/extconf.rb
+++ b/ext/digest/blake3/extconf.rb
@@ -82,26 +82,9 @@ $objs = objs.map { |o| "#{o}.#{$OBJEXT}" }
 
 have_header("sys/cdefs.h")
 
-checking_for("C11 atomics") do
-  ok = try_compile(<<~C)
-    static _Atomic int atomic_int = 0;
-    static int t(void) {return atomic_int;}
-    #{MAIN_DOES_NOTHING 't'}
-  C
-  unless ok
-    $defs << "-DBLAKE3_ATOMICS=0"
-  end
-  ok
-end
-
 $preload = %w[digest]
 
-create_makefile("digest/blake3") do |mk|
-  mk.grep(/^CPPFLAGS *=/) {|m|
-    m.sub!(/(?=-DRUBY_EXTCONF_H)/) {[$defs, ''].join(' ')}
-  }
-  mk
-end
+create_makefile("digest/blake3")
 
 # Emit one explicit compile rule per SIMD backend so each gets its own
 # instruction-set flag.  mkmf's implicit .c.o rule compiles every object with


### PR DESCRIPTION
Revert commits:
- "Pass config macros via command line" d3bcdccba3966d862390fb45de4289b3c8b25fe4
- "Don't use _Atomic in C99 mode" 505c2d159fe0757e0dda5b9d3505711e3ff3c36e