### PR TITLE
Raise FrozenError when modifying a frozen digest

### DIFF
--- a/ext/digest/digest.c
+++ b/ext/digest/digest.c
@@ -266,7 +266,11 @@ rb_digest_instance_digest(int argc, VALUE *argv, VALUE self)
 static VALUE
 rb_digest_instance_digest_bang(VALUE self)
 {
-    VALUE value = rb_funcall(self, id_finish, 0);
+    VALUE value;
+
+    rb_check_frozen(self);
+
+    value = rb_funcall(self, id_finish, 0);
     rb_funcall(self, id_reset, 0);
 
     return value;
@@ -311,7 +315,11 @@ rb_digest_instance_hexdigest(int argc, VALUE *argv, VALUE self)
 static VALUE
 rb_digest_instance_hexdigest_bang(VALUE self)
 {
-    VALUE value = rb_funcall(self, id_finish, 0);
+    VALUE value;
+
+    rb_check_frozen(self);
+
+    value = rb_funcall(self, id_finish, 0);
     rb_funcall(self, id_reset, 0);
 
     return hexencode_str_new(value);
@@ -683,6 +691,8 @@ rb_digest_base_reset(VALUE self)
     rb_digest_metadata_t *algo;
     void *pctx;
 
+    rb_check_frozen(self);
+
     algo = get_digest_obj_metadata(self);
 
     TypedData_Get_Struct(self, void, &digest_type, pctx);
@@ -704,6 +714,8 @@ rb_digest_base_update(VALUE self, VALUE str)
 {
     rb_digest_metadata_t *algo;
     void *pctx;
+
+    rb_check_frozen(self);
 
     algo = get_digest_obj_metadata(self);
 
@@ -732,6 +744,7 @@ rb_digest_base_finish(VALUE self)
     algo->finish_func(pctx, (unsigned char *)RSTRING_PTR(str));
 
     /* avoid potential coredump caused by use of a finished context */
+    /* not frozen-checked: #digest and #hexdigest call this on a clone */
     algo_init(algo, pctx);
 
     return str;

--- a/lib/digest/sha2.rb
+++ b/lib/digest/sha2.rb
@@ -77,6 +77,7 @@ module Digest
     #
     # Reset the digest to the initial state and return self.
     def reset
+      raise FrozenError, "can't modify frozen #{self.class}" if frozen?
       @sha2.reset
       self
     end
@@ -87,6 +88,7 @@ module Digest
     #
     # Update the digest using a given _string_ and return self.
     def update(str)
+      raise FrozenError, "can't modify frozen #{self.class}" if frozen?
       @sha2.update(str)
       self
     end

--- a/test/digest/test_digest.rb
+++ b/test/digest/test_digest.rb
@@ -81,6 +81,42 @@ module TestDigest
     assert_equal(md1, md2, self.class::ALGO)
   end
 
+  def test_frozen
+    md = self.class::ALGO.new
+    md << "a"
+    md.freeze
+
+    assert_raise(FrozenError) { md.update("b") }
+    assert_raise(FrozenError) { md << "b" }
+    assert_raise(FrozenError) { md.reset }
+    assert_raise(FrozenError) { md.digest! }
+    assert_raise(FrozenError) { md.hexdigest! }
+    assert_raise(FrozenError) { md.base64digest! }
+    assert_raise(FrozenError) { md.digest("b") }
+    assert_raise(FrozenError) { md.hexdigest("b") }
+
+    assert_equal(self.class::ALGO.hexdigest("a"), md.hexdigest)
+  end unless RUBY_ENGINE == "jruby"
+
+  def test_new_keeps_singleton
+    md = self.class::ALGO.new
+    md.extend(Module.new { def extended_marker; end })
+    def md.singleton_marker; end
+
+    assert_respond_to(md.new, :extended_marker)
+    assert_respond_to(md.new, :singleton_marker)
+  end
+
+  def test_frozen_copy
+    md = self.class::ALGO.new
+    md << "a"
+    md.freeze
+
+    assert_equal(self.class::ALGO.hexdigest("a"), md.clone.hexdigest)
+    assert_equal(self.class::ALGO.hexdigest("a"), md.dup.hexdigest)
+    assert_raise(FrozenError) { md.new }
+  end unless RUBY_ENGINE == "jruby"
+
   def test_s_file
     Tempfile.create("test_digest_file", mode: File::BINARY) { |tmpfile|
       str = "hello, world.\r\n"
@@ -173,6 +209,32 @@ module TestDigest
   end if defined?(Digest::SHA512)
 
   class TestSHA2 < Test::Unit::TestCase
+
+  def test_frozen
+    md = Digest::SHA2.new
+    md << "a"
+    md.freeze
+
+    assert_raise(FrozenError) { md.update("b") }
+    assert_raise(FrozenError) { md.reset }
+    assert_raise(FrozenError) { md.digest! }
+    assert_raise(FrozenError) { md.hexdigest! }
+    assert_raise(FrozenError) { md.base64digest! }
+    assert_raise(FrozenError) { md.digest("b") }
+    assert_raise(FrozenError) { md.hexdigest("b") }
+
+    assert_equal(Digest::SHA256.hexdigest("a"), md.hexdigest)
+  end unless RUBY_ENGINE == "jruby"
+
+  def test_frozen_copy
+    md = Digest::SHA2.new
+    md << "a"
+    md.freeze
+
+    assert_equal(Digest::SHA256.hexdigest("a"), md.clone.hexdigest)
+    assert_equal(Digest::SHA256.hexdigest("a"), md.dup.hexdigest)
+    assert_raise(FrozenError) { md.new }
+  end unless RUBY_ENGINE == "jruby"
 
   def test_s_file
     Tempfile.create("test_digest_file") { |tmpfile|


### PR DESCRIPTION
Freezing a digest does not prevent mutation.

```ruby
md = Digest::SHA256.new
md << "a"
md.freeze

md.update("b")   # no error
md.hexdigest     # => "fb8e20fc..." the state is changed
```

`Digest::Base#initialize_copy` calls `rb_check_frozen`. Other methods do not.

- `Digest::Base#update` and `#reset` write to the context directly.
- `Digest::Instance#digest!` and `#hexdigest!` call `finish`, then `reset`. `rb_digest_base_finish` also re-initializes the context for the coredump guard. So the receiver is wiped, and nothing raises.
- `Digest::SHA2#update` and `#reset` use an inner digest. Freezing the wrapper does not freeze it.

This patch checks the receiver in these methods.

`#base64digest!` calls `#digest!`, so it is covered. `#digest(str)` and `#hexdigest(str)` call `reset` first, so they are covered too. `finish` is not checked. `#digest` and `#hexdigest` call it on a clone, and the clone is frozen when the receiver is frozen. I added a comment about this.

Behavior change: mutating a frozen digest raises `FrozenError` now. Before, it succeeded silently. `Instance#new` is `clone().reset()`, so it also raises when the receiver is frozen. `#clone` and `#dup` still work.